### PR TITLE
fix: skip apply when branch is out of date

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,16 +167,16 @@ runs:
         then
           echo "Branch is not '${{ inputs.apply-branch }}', 'terraform apply' will not be executed."
           exit 0
-        else
-          # Update remote references
-          git fetch
-
-          if [[ "$(git rev-parse origin/HEAD)" != "$(git rev-parse HEAD)" ]]
-          then
-            echo "Branch is not up to date, 'terraform apply' will not be executed."
-            exit 0
-          else
-            cd ${{ inputs.path }}
-            terraform apply -auto-approve
-          fi
         fi
+
+        # Update remote references
+        git fetch
+
+        if [[ "$(git rev-parse origin/HEAD)" != "$(git rev-parse HEAD)" ]]
+        then
+          echo "Branch is not up to date, 'terraform apply' will not be executed."
+          exit 1
+        fi
+
+        cd ${{ inputs.path }}
+        terraform apply -auto-approve

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,20 @@ runs:
     - name: Terraform Apply
       shell: bash
       run: |
-        if [[ '${{ github.ref }}' == 'refs/heads/${{ inputs.apply-branch }}' ]]; then
-          cd ${{ inputs.path }}
-          terraform apply -auto-approve
+        if [[ '${{ github.ref }}' != 'refs/heads/${{ inputs.apply-branch }}' ]]
+        then
+          echo "Branch is not '${{ inputs.apply-branch }}', 'terraform apply' will not be executed."
+          exit 0
+        else
+          # Update remote references
+          git fetch
+
+          if [[ "$(git rev-parse origin/HEAD)" != "$(git rev-parse HEAD)" ]]
+          then
+            echo "Branch is not up to date, 'terraform apply' will not be executed."
+            exit 0
+          else
+            cd ${{ inputs.path }}
+            terraform apply -auto-approve
+          fi
         fi


### PR DESCRIPTION
```
if [[ '${{ github.ref }}' != 'refs/heads/${{ inputs.apply-branch }}' ]]
then
  echo "Branch is not '${{ inputs.apply-branch }}', 'terraform apply' will not be executed."
  exit 0
fi

# Update remote references
git fetch

if [[ "$(git rev-parse origin/HEAD)" != "$(git rev-parse HEAD)" ]]
then
  echo "Branch is not up to date, 'terraform apply' will not be executed."
  exit 1
fi

cd ${{ inputs.path }}
terraform apply -auto-approve
```


If "current-branch is not apply-branch"; echo and exit
If "current-branch is not up-to-date"; echo and exit

If "current-branch is apply-branch" and "current-branch is up-to-date"; run `terraform apply`
