### PR TITLE
(fix) Use Step Outputs to Pass stdout and stderr easier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,12 +113,12 @@ runs:
 
           const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID
           const run_link = '<a href="' + run_url + '">Actions</a>.'
-          const plan_file = `
+          const raw_plan = `
           ${{ steps.plan.outputs.stdout }}
           ${{ steps.plan.outputs.stderr }}
           `
-          const plan = plan_file.length > 65000 ? " ..." + plan_file.toString().substring(plan_file.length - 65000, plan_file.length) : plan_file
-          const truncated_message = plan_file.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
+          const plan = raw_plan.length > 65000 ? " ..." + raw_plan.toString().substring(raw_plan.length - 65000, raw_plan.length) : raw_plan
+          const truncated_message = raw_plan.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
 
           const commentTitle = `### Terraform Status ${tag}`;
           const commentContent = `
@@ -150,7 +150,7 @@ runs:
              comment.body.includes(commentTitle)
           );
 
-          if (commentContent.includes("No changes.")) {
+          if (raw_plan.includes("No changes.")) {
             if (githubActionsBotComment) {
               await github.issues.deleteComment({
                 comment_id: githubActionsBotComment.id,

--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,9 @@ runs:
           <details>
           <summary>Show Plan</summary>
 
-          \`\`\`${plan}\`\`\`
+          \`\`\`
+          ${plan}
+          \`\`\`
 
           </details>
           ${truncated_message}

--- a/action.yml
+++ b/action.yml
@@ -85,12 +85,11 @@ runs:
       run: |
         if [[ '${{ github.ref }}' != 'refs/heads/${{ inputs.apply-branch }}' ]]; then
           cd ${{ inputs.path }}
-          if terraform plan -no-color -lock-timeout=60s -lock=${{ inputs.lock-for-plan }} >${GITHUB_WORKSPACE}/plan.out 2>&1; then
+          if terraform plan -no-color -lock-timeout=60s -lock=${{ inputs.lock-for-plan }}; then
             echo "::set-output name=plan-outcome::success"
           else
             echo "::set-output name=plan-outcome::failure"
           fi
-          cat ${GITHUB_WORKSPACE}/plan.out
         fi
 
     - name: Create/Update Comment
@@ -114,8 +113,10 @@ runs:
 
           const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID
           const run_link = '<a href="' + run_url + '">Actions</a>.'
-          const fs = require('fs')
-          const plan_file = fs.readFileSync('plan.out', 'utf8')
+          const plan_file = `
+          ${{ steps.plan.outputs.stdout }}
+          ${{ steps.plan.outputs.stderr }}
+          `
           const plan = plan_file.length > 65000 ? " ..." + plan_file.toString().substring(plan_file.length - 65000, plan_file.length) : plan_file
           const truncated_message = plan_file.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
 


### PR DESCRIPTION
* Fixes issues with the plan being in the direct output and in the `::set-output::` directive inside the `terraform-wrapper`.  Also allows simplification
* Fixes code block formatting issues
* Checks raw plan for "No changes" in case for some reason it gets truncated.