### PR TITLE
docs: Update examples to use modern dependencies, prevent set-output deprecation

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update Semver Tags
         uses: tchupp/actions-update-semver-tags@v1

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The following snippet from an example job, [which can be found below](#simple-se
 ...
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ~1.0.0
           cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
@@ -125,10 +125,10 @@ jobs:
       TF_WORKSPACE: "default"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ~1.0.0
           cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
@@ -174,10 +174,10 @@ jobs:
       TF_WORKSPACE: "default"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ~1.0.0
           cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
@@ -230,10 +230,10 @@ jobs:
       TF_WORKSPACE: "${{ matrix.env }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ~1.0.0
           cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
@@ -269,10 +269,10 @@ jobs:
       TF_WORKSPACE: "default"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ~1.0.0
           cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
@@ -311,10 +311,10 @@ jobs:
       TF_WORKSPACE: "default"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ~1.0.0
           cli_config_credentials_token: ${{ secrets.TF_TOKEN }}


### PR DESCRIPTION
What it boils down to is the version of `hashicorp/setup-terraform` needs to use version of the NPM package @actions/core to 1.10.0.

In the v1 line of the setup-terraform they're still using @actions/core that's a bit older. https://github.com/hashicorp/setup-terraform/blob/v1/package.json#L22

Bumping to the v2 version of hashicorp/setup-terraform should clean up as it's ultimately what's hiding behind that terraform-bin wrapper that's being executed in the pipeline.

This fixes the docs to make that a bit simpler to adopt.

Last fix for #25 done retroactively.